### PR TITLE
fix TabError in initial code

### DIFF
--- a/editor/initial_code/python_3
+++ b/editor/initial_code/python_3
@@ -11,6 +11,6 @@ if __name__ == '__main__':
     
     # These "asserts" are used for self-checking and not for an auto-testing
     assert home_coming([1, 1, 4, 1, 4, 4], 2) == 4,             "Example #1"
-	assert home_coming([1, 2, 5, 3, 4, 5, 6, 7], 1) == 6,       "Example #2"
-	assert home_coming([1, 2, 8, 8, 8, 8, 8, 3, 4, 1], 1) == 4, "Example #3"
+    assert home_coming([1, 2, 5, 3, 4, 5, 6, 7], 1) == 6,       "Example #2"
+    assert home_coming([1, 2, 8, 8, 8, 8, 8, 3, 4, 1], 1) == 4, "Example #3"
     print("Coding complete? Click 'Check' to earn cool rewards!")


### PR DESCRIPTION
```
  File "editor/initial_code/python_3", line 14
    assert home_coming([1, 2, 5, 3, 4, 5, 6, 7], 1) == 6,       "Example #2"
                                                                           ^
TabError: inconsistent use of tabs and spaces in indentation
```